### PR TITLE
Modified IKEv2 signalling to include null encryption in TNGFUE

### DIFF
--- a/src/crypto/crypto_openssl.c
+++ b/src/crypto/crypto_openssl.c
@@ -756,6 +756,11 @@ struct crypto_cipher * crypto_cipher_init(enum crypto_cipher_alg alg,
 		cipher = EVP_rc2_ecb();
 		break;
 #endif /* OPENSSL_NO_RC2 */
+#ifndef OPENSSL_NO_NULL
+	case CRYPTO_CIPHER_NULL:
+		cipher = EVP_enc_null();
+		break;
+#endif /* OPENSSL_NO_NULL */
 	default:
 		os_free(ctx);
 		return NULL;

--- a/src/eap_common/ikev2_common.c
+++ b/src/eap_common/ikev2_common.c
@@ -34,7 +34,8 @@ static const struct ikev2_prf_alg ikev2_prf_algs[] = {
 
 static const struct ikev2_encr_alg ikev2_encr_algs[] = {
 	{ ENCR_AES_CBC, 16, 16 }, /* only 128-bit keys supported for now */
-	{ ENCR_3DES, 24, 8 }
+	{ ENCR_3DES, 24, 8 },
+	{ ENCR_NULL, 0, 0 },
 };
 
 #define NUM_ENCR_ALGS ARRAY_SIZE(ikev2_encr_algs)
@@ -185,6 +186,9 @@ int ikev2_encr_encrypt(int alg, const u8 *key, size_t key_len, const u8 *iv,
 	case ENCR_AES_CBC:
 		encr_alg = CRYPTO_CIPHER_ALG_AES;
 		break;
+	case ENCR_NULL:
+		encr_alg = CRYPTO_CIPHER_NULL;
+		break;
 	default:
 		wpa_printf(MSG_DEBUG, "IKEV2: Unsupported encr alg %d", alg);
 		return -1;
@@ -219,6 +223,9 @@ int ikev2_encr_decrypt(int alg, const u8 *key, size_t key_len, const u8 *iv,
 		break;
 	case ENCR_AES_CBC:
 		encr_alg = CRYPTO_CIPHER_ALG_AES;
+		break;
+	case ENCR_NULL:
+		encr_alg = CRYPTO_CIPHER_NULL;
 		break;
 	default:
 		wpa_printf(MSG_DEBUG, "IKEV2: Unsupported encr alg %d", alg);
@@ -603,9 +610,16 @@ int ikev2_build_encrypted(int encr_id, int integ_id, struct ikev2_keys *keys,
 		return -1;
 	}
 
-	pad_len = iv_len - (wpabuf_len(plain) + 1) % iv_len;
-	if (pad_len == iv_len)
+	if (iv_len != 0) {
+		// Prevent floating point exception when iv is not used
+		pad_len = iv_len - (wpabuf_len(plain) + 1) % iv_len;
+		if (pad_len == iv_len)
+			pad_len = 0;
+	} else {
+		// Avoid to use padding when not necessary (e.g. ENC_NULL)
 		pad_len = 0;
+	}
+
 	wpabuf_put(plain, pad_len);
 	wpabuf_put_u8(plain, pad_len);
 

--- a/src/eap_peer/eap_vendor_test.c
+++ b/src/eap_peer/eap_vendor_test.c
@@ -1707,7 +1707,7 @@ void eap_vendor_test_ikev2_conn(struct eap_sm *sm, void *priv)
 	data->ikev2.sa.proposal = malloc(sizeof (struct ikev2_proposal_data));
 	data->ikev2.sa.proposal[0].integ = 2; // AUTH_HMAC_SHA1_96
 	data->ikev2.sa.proposal[0].prf = 2; // PRF_HMAC_SHA1
-	data->ikev2.sa.proposal[0].encr = 12; // ENCR_AES_CBC
+	data->ikev2.sa.proposal[0].encr = 11; // ENCR_NULL
 	data->ikev2.sa.proposal[0].dh = 14; // DH_2048_BIT_MODP
 	data->ikev2.sa.proposal[0].esn = 0; // Extended Sequence Numbers
 	data->ikev2.sa.proposal[0].proposal_num = 1;


### PR DESCRIPTION
### Summary

This pull request updates the `tngfue` to include the null encryption during the IKEv2 signalling phase.

### Changes

- Added ENCR_NULL as a supported encryption algorithm for TNGFUE;
- Implemented ENCR_NULL init/encrypt/decrypt operations using CRYPTO_CIPHER_NULL from the OpenSSL library;
- Fixed floating point exception caused by lV length = 0 (initialization vector is not used by ENCR_NULL [[1]]( https://datatracker.ietf.org/doc/html/rfc2410#section-3));
- Added field Pad Length = 0 (no padding required for ENCR_NULL [[2]](https://datatracker.ietf.org/doc/html/rfc2410#section-2.3));
- Added ENCR_NULL ID (11) in the IKE_SA_INIT SA proposal, replacing AES_CBC (12);

### Related Issues

- Related to https://github.com/free5gc/tngf/issues/13
- Depends on https://github.com/free5gc/tngf/pull/14